### PR TITLE
Update the xwikidoc standard for Panel

### DIFF
--- a/src/main/resources/TaskManager/TaskManagerPanel.xml
+++ b/src/main/resources/TaskManager/TaskManagerPanel.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.1">
+<xwikidoc>
   <web>TaskManager</web>
   <name>TaskManagerPanel</name>
   <language/>


### PR DESCRIPTION
The syntax of the xwikidoc document for the TaskManagerPanel is incorrect and generate a different file each time `mvn xar:format` is runned, even with no change in this document.
