### PR TITLE
Add missing translation for 'Late' status

### DIFF
--- a/src/main/resources/TaskManager/TaskManagerTranslations.fr.xml
+++ b/src/main/resources/TaskManager/TaskManagerTranslations.fr.xml
@@ -68,6 +68,7 @@ TaskManager.TaskManagerClass_status=Statut
 TaskManager.TaskManagerClass_status_InProgress=En cours
 TaskManager.TaskManagerClass_status_ToDo=À faire
 TaskManager.TaskManagerClass_status_Done=Effectuée
+TaskManager.TaskManagerClass_status_Late=En retard
 TaskManager.TaskManagerClass_severity=Importance
 TaskManager.TaskManagerClass_severity_Medium=Moyenne
 TaskManager.TaskManagerClass_severity_Low=Basse

--- a/src/main/resources/TaskManager/TaskManagerTranslations.xml
+++ b/src/main/resources/TaskManager/TaskManagerTranslations.xml
@@ -103,6 +103,7 @@ TaskManager.TaskManagerClass_status=Status
 TaskManager.TaskManagerClass_status_InProgress=In Progress
 TaskManager.TaskManagerClass_status_ToDo=To Do
 TaskManager.TaskManagerClass_status_Done=Done
+TaskManager.TaskManagerClass_status_Late=Late
 TaskManager.TaskManagerClass_severity=Priority
 TaskManager.TaskManagerClass_severity_Medium=Medium
 TaskManager.TaskManagerClass_severity_Low=Low


### PR DESCRIPTION
The virtual 'Late' status is used for displaying and colouring tasks that are not 'Done' and for which the due date is passed.
