### PR TITLE
Create a custom displayer for 'progress' field

### DIFF
--- a/src/main/resources/TaskManager/TaskManagerClass.xml
+++ b/src/main/resources/TaskManager/TaskManagerClass.xml
@@ -235,8 +235,12 @@
 {{html}}
   #if($type=='view')
       &lt;div class="progress"&gt;
-        &lt;div class="progress-bar progress-bar-striped" role="progressbar" style="width: ${value}%"&gt;
-          ${value} %
+        &lt;div class="progress-bar progress-bar-striped" role="progressbar" style="width: $!{value}%"&gt;
+          #if($value &amp;&amp; $value != '')
+            &lt;span&gt;$!{value}%&lt;/span&gt;
+          #else
+            &lt;span&gt;0%&lt;/span&gt;
+          #end
         &lt;/div&gt;
       &lt;/div&gt;
   #else


### PR DESCRIPTION
Use the `progress` field of TaskManagerClass to display progress bar.  It uses the progress bar from Bootstrap but should display at least the number for version of XWiki that doesn't support Bootstrap (not tested on these versions).
